### PR TITLE
feat(FingerController): provide threshold to determine lerp transition

### DIFF
--- a/Documentation/API/FingerController.md
+++ b/Documentation/API/FingerController.md
@@ -16,6 +16,7 @@ Controls the finger armature.
   * [CurrentCurlValue]
   * [FloatData]
   * [FloatLimits]
+  * [ForceTransitionThreshold]
   * [InputSource]
   * [NormalizedFloatData]
   * [OverrideValue]
@@ -26,6 +27,7 @@ Controls the finger armature.
   * [ClearFloatData()]
   * [ClearFloatLimits()]
   * [ClearSourceInput()]
+  * [DetermineCurlMotion(Single)]
   * [GetDirectionOffset(Single, Single)]
   * [OnDisable()]
   * [Process()]
@@ -133,6 +135,16 @@ The minimum and maximum limits of the given [FloatData].
 public FloatRange FloatLimits { get; set; }
 ```
 
+#### ForceTransitionThreshold
+
+The distance the current curl value has to be away from the input curl value for it to transition to that state.
+
+##### Declaration
+
+```
+public float ForceTransitionThreshold { get; set; }
+```
+
 #### InputSource
 
 The source of the input for the finger.
@@ -224,6 +236,22 @@ Clears [InputSource].
 ```
 public virtual void ClearSourceInput()
 ```
+
+#### DetermineCurlMotion(Single)
+
+Determines the way in which the curl motion will be processed.
+
+##### Declaration
+
+```
+protected virtual void DetermineCurlMotion(float targetValue)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Single | targetValue | The target value for the finger curl. |
 
 #### GetDirectionOffset(Single, Single)
 
@@ -404,6 +432,7 @@ IProcessable
 [CurrentCurlValue]: #CurrentCurlValue
 [FloatData]: #FloatData
 [FloatLimits]: #FloatLimits
+[ForceTransitionThreshold]: #ForceTransitionThreshold
 [InputSource]: #InputSource
 [NormalizedFloatData]: #NormalizedFloatData
 [OverrideValue]: #OverrideValue
@@ -414,6 +443,7 @@ IProcessable
 [ClearFloatData()]: #ClearFloatData
 [ClearFloatLimits()]: #ClearFloatLimits
 [ClearSourceInput()]: #ClearSourceInput
+[DetermineCurlMotion(Single)]: #DetermineCurlMotionSingle
 [GetDirectionOffset(Single, Single)]: #GetDirectionOffsetSingle-Single
 [OnDisable()]: #OnDisable
 [Process()]: #Process

--- a/Runtime/SharedResources/Scripts/FingerController.cs
+++ b/Runtime/SharedResources/Scripts/FingerController.cs
@@ -162,6 +162,23 @@
                 transitionSpeed = value;
             }
         }
+        [Tooltip("The distance the current curl value has to be away from the input curl value for it to transition to that state.")]
+        [SerializeField]
+        private float forceTransitionThreshold = 0.9f;
+        /// <summary>
+        /// The distance the current curl value has to be away from the input curl value for it to transition to that state.
+        /// </summary>
+        public float ForceTransitionThreshold
+        {
+            get
+            {
+                return forceTransitionThreshold;
+            }
+            set
+            {
+                forceTransitionThreshold = value;
+            }
+        }
         #endregion
 
         #region Reference Settings
@@ -321,23 +338,36 @@
         /// </summary>
         protected virtual void ProcessFingerCurl()
         {
+            float targetValue = 0f;
             switch (InputSource)
             {
                 case InputType.Override:
-                    StartTransition(OverrideValue);
+                    targetValue = OverrideValue;
                     break;
                 case InputType.Float:
-                    if (FloatData != null)
-                    {
-                        SetFingerCurlPosition(NormalizedFloatData);
-                    }
+                    targetValue = FloatData != null ? NormalizedFloatData : 0f;
                     break;
                 case InputType.Boolean:
-                    if (BoolData != null)
-                    {
-                        StartTransition(BoolData.Value ? 1f : 0f);
-                    }
+                    targetValue = BoolData != null ? BoolData.Value ? 1f : 0f : 0f;
                     break;
+            }
+
+            DetermineCurlMotion(targetValue);
+        }
+
+        /// <summary>
+        /// Determines the way in which the curl motion will be processed.
+        /// </summary>
+        /// <param name="targetValue">The target value for the finger curl.</param>
+        protected virtual void DetermineCurlMotion(float targetValue)
+        {
+            if (Mathf.Abs(CurrentCurlValue - targetValue) > ForceTransitionThreshold)
+            {
+                StartTransition(targetValue);
+            }
+            else
+            {
+                SetFingerCurlPosition(targetValue);
             }
         }
 


### PR DESCRIPTION
Previously the lerped transition would only happen for the boolean or
override value and the float value would never lerp. This has now been
customised further so it is possible to lerp a float value if the
current curl value and the given target curl value exceed the
transition threshold.