### PR TITLE
feat(FingerController): add curl limits to restrict curl amount

### DIFF
--- a/Documentation/API/FingerController.md
+++ b/Documentation/API/FingerController.md
@@ -13,6 +13,7 @@ Controls the finger armature.
   * [AnimationController]
   * [AnimationLayer]
   * [BoolData]
+  * [CurlLimits]
   * [CurrentCurlValue]
   * [FloatData]
   * [FloatLimits]
@@ -32,10 +33,12 @@ Controls the finger armature.
   * [OnDisable()]
   * [Process()]
   * [ProcessFingerCurl()]
+  * [SetCurlLimitsMaximum(Single)]
+  * [SetCurlLimitsMinimum(Single)]
   * [SetFingerCurlPosition(Single)]
+  * [SetFloatLimitsMaximum(Single)]
   * [SetFloatLimitsMinimum(Single)]
   * [SetSourceInput(Int32)]
-  * [SetThumbFloatLimitsMaximum(Single)]
   * [StartTransition(Single)]
   * [TransitionFingerCurlPosition(Single)]
 * [Implements]
@@ -103,6 +106,16 @@ The BooleanAction that contains the finger curl data.
 
 ```
 public BooleanAction BoolData { get; set; }
+```
+
+#### CurlLimits
+
+The minimum and maximum limits that the finger curl can extend or retract to.
+
+##### Declaration
+
+```
+public FloatRange CurlLimits { get; set; }
 ```
 
 #### CurrentCurlValue
@@ -302,6 +315,38 @@ Processes the curl of the finger.
 protected virtual void ProcessFingerCurl()
 ```
 
+#### SetCurlLimitsMaximum(Single)
+
+Sets the maximum value in [CurlLimits].
+
+##### Declaration
+
+```
+public virtual void SetCurlLimitsMaximum(float value)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Single | value | The value to set maximum to. |
+
+#### SetCurlLimitsMinimum(Single)
+
+Sets the minimum value in [CurlLimits].
+
+##### Declaration
+
+```
+public virtual void SetCurlLimitsMinimum(float value)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Single | value | The value to set minimum to. |
+
 #### SetFingerCurlPosition(Single)
 
 Sets the finger curl position to the given value.
@@ -317,6 +362,22 @@ protected virtual void SetFingerCurlPosition(float targetValue)
 | Type | Name | Description |
 | --- | --- | --- |
 | System.Single | targetValue | The target position to use. |
+
+#### SetFloatLimitsMaximum(Single)
+
+Sets the maximum value in [FloatLimits].
+
+##### Declaration
+
+```
+public virtual void SetFloatLimitsMaximum(float value)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Single | value | The value to set maximum to. |
 
 #### SetFloatLimitsMinimum(Single)
 
@@ -349,22 +410,6 @@ public virtual void SetSourceInput(int inputTypeIndex)
 | Type | Name | Description |
 | --- | --- | --- |
 | System.Int32 | inputTypeIndex | The index of the [FingerController.InputType]. |
-
-#### SetThumbFloatLimitsMaximum(Single)
-
-Sets the maximum value in [FloatLimits].
-
-##### Declaration
-
-```
-public virtual void SetThumbFloatLimitsMaximum(float value)
-```
-
-##### Parameters
-
-| Type | Name | Description |
-| --- | --- | --- |
-| System.Single | value | The value to set maximum to. |
 
 #### StartTransition(Single)
 
@@ -416,10 +461,12 @@ IProcessable
 [FloatData]: FingerController.md#FloatData
 [FloatLimits]: FingerController.md#FloatLimits
 [InputSource]: FingerController.md#InputSource
+[CurlLimits]: FingerController.md#CurlLimits
+[CurlLimits]: FingerController.md#CurlLimits
+[FloatLimits]: FingerController.md#FloatLimits
 [FloatLimits]: FingerController.md#FloatLimits
 [InputSource]: FingerController.md#InputSource
 [FingerController.InputType]: FingerController.InputType.md
-[FloatLimits]: FingerController.md#FloatLimits
 [Inheritance]: #Inheritance
 [Namespace]: #Namespace
 [Syntax]: #Syntax
@@ -429,6 +476,7 @@ IProcessable
 [AnimationController]: #AnimationController
 [AnimationLayer]: #AnimationLayer
 [BoolData]: #BoolData
+[CurlLimits]: #CurlLimits
 [CurrentCurlValue]: #CurrentCurlValue
 [FloatData]: #FloatData
 [FloatLimits]: #FloatLimits
@@ -448,10 +496,12 @@ IProcessable
 [OnDisable()]: #OnDisable
 [Process()]: #Process
 [ProcessFingerCurl()]: #ProcessFingerCurl
+[SetCurlLimitsMaximum(Single)]: #SetCurlLimitsMaximumSingle
+[SetCurlLimitsMinimum(Single)]: #SetCurlLimitsMinimumSingle
 [SetFingerCurlPosition(Single)]: #SetFingerCurlPositionSingle
+[SetFloatLimitsMaximum(Single)]: #SetFloatLimitsMaximumSingle
 [SetFloatLimitsMinimum(Single)]: #SetFloatLimitsMinimumSingle
 [SetSourceInput(Int32)]: #SetSourceInputInt32
-[SetThumbFloatLimitsMaximum(Single)]: #SetThumbFloatLimitsMaximumSingle
 [StartTransition(Single)]: #StartTransitionSingle
 [TransitionFingerCurlPosition(Single)]: #TransitionFingerCurlPositionSingle
 [Implements]: #Implements

--- a/Runtime/SharedResources/Scripts/FingerController.cs
+++ b/Runtime/SharedResources/Scripts/FingerController.cs
@@ -145,6 +145,23 @@
                 floatLimits = value;
             }
         }
+        [Tooltip("The minimum and maximum limits that the finger curl can extend or retract to.")]
+        [SerializeField]
+        private FloatRange curlLimits = new FloatRange(0f, 1f);
+        /// <summary>
+        /// The minimum and maximum limits that the finger curl can extend or retract to.
+        /// </summary>
+        public FloatRange CurlLimits
+        {
+            get
+            {
+                return curlLimits;
+            }
+            set
+            {
+                curlLimits = value;
+            }
+        }
         [Tooltip("The speed in which to transition the finger to the boolean destination value.")]
         [SerializeField]
         private float transitionSpeed = 0.3f;
@@ -297,7 +314,7 @@
         /// Sets the maximum value in <see cref="FloatLimits"/>.
         /// </summary>
         /// <param name="value">The value to set maximum to.</param>
-        public virtual void SetThumbFloatLimitsMaximum(float value)
+        public virtual void SetFloatLimitsMaximum(float value)
         {
             if (!this.IsValidState())
             {
@@ -305,6 +322,34 @@
             }
 
             FloatLimits = new FloatRange(FloatLimits.minimum, value);
+        }
+
+        /// <summary>
+        /// Sets the minimum value in <see cref="CurlLimits"/>.
+        /// </summary>
+        /// <param name="value">The value to set minimum to.</param>
+        public virtual void SetCurlLimitsMinimum(float value)
+        {
+            if (!this.IsValidState())
+            {
+                return;
+            }
+
+            CurlLimits = new FloatRange(value, CurlLimits.maximum);
+        }
+
+        /// <summary>
+        /// Sets the maximum value in <see cref="CurlLimits"/>.
+        /// </summary>
+        /// <param name="value">The value to set maximum to.</param>
+        public virtual void SetCurlLimitsMaximum(float value)
+        {
+            if (!this.IsValidState())
+            {
+                return;
+            }
+
+            CurlLimits = new FloatRange(CurlLimits.minimum, value);
         }
 
         /// <summary>
@@ -352,7 +397,7 @@
                     break;
             }
 
-            DetermineCurlMotion(targetValue);
+            DetermineCurlMotion(Mathf.Clamp(targetValue, CurlLimits.minimum, CurlLimits.maximum));
         }
 
         /// <summary>


### PR DESCRIPTION
The new CurlLimits property allows the minimum and maximum level of
finger curl to be applied so the input may not curl the finger all
the way to the maximum or even all the way to the minimum.

There was also a badly named setter method that still referred to
Thumb in the method name, this has now been removed which is
technically a change that could break things for existing users but
as this package is so new let's hope it is snuck in under the radar
so a new major version isn't needed.