### PR TITLE
fix(package.json): add missing object follower dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     },
     "dependencies": {
         "io.extendreality.zinnia.unity": "2.1.0",
-        "io.extendreality.tilia.utilities.shaders.unity": "1.3.0"
+        "io.extendreality.tilia.utilities.shaders.unity": "1.3.0",
+        "io.extendreality.tilia.mutators.objectfollower.unity": "2.0.2"
     },
     "files": [
         "*.md",


### PR DESCRIPTION
The ObjectFollower package is a dependency of this package and was
not included in the package.json which caused errors on installation
if this package was not already installed.

It has now been included as standard in the package.json file.